### PR TITLE
use define-package instead of defpackage for ffi packages

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1,5 +1,5 @@
 (in-package :cl-user)
-(defpackage :sdl2-ttf
+(uiop:define-package :sdl2-ttf
   (:use #:cl
         #:alexandria
         #:autowrap.minimal


### PR DESCRIPTION
Sometime it is valuable to asdf:load-system with :force t in order to
find warnings. However due to the design of defpackage this will error
as some of the symbols exported for sdl2-ttf are exported by
define-*render-function and friends.

By moving to define-package we avoid this issue.