### PR TITLE
Fix surface collection.

### DIFF
--- a/src/render.lisp
+++ b/src/render.lisp
@@ -32,7 +32,7 @@
                                                                           green
                                                                           blue
                                                                           alpha))))
-         (sdl2:free-surface ptr)))))
+         (sdl-free-surface ptr)))))
 
 ;;Shaded functions require a separate macro because issue #2 (bg and fg colors)
 ;;There is some repeated code here
@@ -57,7 +57,7 @@
                                                                           bg-green
                                                                           bg-blue
                                                                           bg-alpha))))
-         (sdl2:free-surface ptr)))))
+         (sdl-free-surface ptr)))))
 
 (define-render-function "Solid" "Text")
 (define-render-function "Solid" "UTF8")


### PR DESCRIPTION
During finalization of surfaces created with this library, the following error occurs:
```
WARNING:                                                                                                                                                                                             
   Error calling finalizer #<CLOSURE (LAMBDA ()                                                                                                                                                      
                                       :IN                                                                                                                                                           
                                       RENDER-TEXT-SOLID) {10032CB4FB}>:                                                                                                                             
  #<TYPE-ERROR expected-type: AUTOWRAP:WRAPPER                                                                                                                                                       
               datum: #.(SB-SYS:INT-SAP #X7FFFE00A6CB0)>
```

This appears to be because we are calling `SDL2:FREE-SURFACE` which expects a wrapper object instead of the low-level FFI function `SDL-FREE-SURFACE` which accepts a pointer.