### PR TITLE
Added trivial-garbage to explicit dependencies

### DIFF
--- a/sdl2-ttf.asd
+++ b/sdl2-ttf.asd
@@ -8,7 +8,7 @@
     :author "Bryan Baraoidan"
     :license "MIT"
     :version "1.0"
-    :depends-on (:alexandria :defpackage-plus :cl-autowrap :sdl2 :cffi-libffi)
+    :depends-on (:alexandria :defpackage-plus :cl-autowrap :sdl2 :cffi-libffi :trivial-garbage)
     :pathname "src"
     :serial t
     :components ((:file "package")


### PR DESCRIPTION
We can't assume trivial-garbage will be brought in as a transitive dependency by cl-sdl2, because it isn't anymore. If we are using the tg package directly, we should specify it as a dependency.